### PR TITLE
update realsense-ros to 4.55.1 

### DIFF
--- a/cabot_people/launch/rs_composite.launch.py
+++ b/cabot_people/launch/rs_composite.launch.py
@@ -94,7 +94,7 @@ def generate_launch_description():
             composable_node_descriptions=[
                 ComposableNode(
                     package='realsense2_camera',
-                    namespace=LaunchConfiguration("camera_name"),
+                    namespace='',
                     plugin='realsense2_camera::RealSenseNodeFactory',
                     name=LaunchConfiguration("camera_name"),
                     parameters=[set_configurable_parameters(configurable_parameters)],

--- a/dependency.repos
+++ b/dependency.repos
@@ -12,4 +12,4 @@ repositories:
   docker/jetson-humble-custom/realsense_ros:
     type: git
     url: https://github.com/IntelRealSense/realsense-ros.git
-    version: 4.51.1
+    version: 4.55.1


### PR DESCRIPTION
This pull request fixed realsense launch script to support realsense-ros 4.55.1.
From the version 4.55.1, camera namespace and camera name are used for topic name (https://github.com/IntelRealSense/realsense-ros/pull/2857).