### PR TITLE
update versions of FRAMOS softwares

### DIFF
--- a/docker/framos/Dockerfile
+++ b/docker/framos/Dockerfile
@@ -42,8 +42,8 @@ RUN cd /tmp && \
     cd FRAMOS_D400e_Software_Package && \
     apt update && \
     apt install -y --no-install-recommends \
-        ./FRAMOS_CameraSuite_4.10.1.0-Linux64_x64.deb \
-        ./FRAMOS-librealsense2-2.50.12-Linux64_x64.deb \
+        ./FRAMOS_CameraSuite_4.10.2.0-Linux64_x64.deb \
+        ./FRAMOS-librealsense2-2.50.13-Linux64_x64.deb \
     && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/framos/Dockerfile.jetson
+++ b/docker/framos/Dockerfile.jetson
@@ -42,8 +42,8 @@ RUN cd /tmp && \
     cd FRAMOS_D400e_Software_Package && \
     apt update && \
     apt install -y --no-install-recommends \
-        ./FRAMOS_CameraSuite_4.10.1.0-Linux64_ARM.deb \
-        ./FRAMOS-librealsense2-2.50.12-Linux64_ARM.deb \
+        ./FRAMOS_CameraSuite_4.10.2.0-Linux64_ARM.deb \
+        ./FRAMOS-librealsense2-2.50.13-Linux64_ARM.deb \
     && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/framos/Dockerfile.with_cuda
+++ b/docker/framos/Dockerfile.with_cuda
@@ -42,8 +42,8 @@ RUN cd /tmp && \
     cd FRAMOS_D400e_Software_Package && \
     apt update && \
     apt install -y --no-install-recommends \
-        ./FRAMOS_CameraSuite_4.10.1.0-Linux64_x64.deb \
-        ./FRAMOS-librealsense2-2.50.12-Linux64_x64.deb \
+        ./FRAMOS_CameraSuite_4.10.2.0-Linux64_x64.deb \
+        ./FRAMOS-librealsense2-2.50.13-Linux64_x64.deb \
     && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/framos/Dockerfile.with_cuda.jetson
+++ b/docker/framos/Dockerfile.with_cuda.jetson
@@ -43,8 +43,8 @@ RUN cd /tmp && \
     cd FRAMOS_D400e_Software_Package && \
     apt update && \
     apt install -y --no-install-recommends \
-        ./FRAMOS_CameraSuite_4.10.1.0-Linux64_ARM.deb \
-        ./FRAMOS-librealsense2-2.50.12-Linux64_ARM.deb \
+        ./FRAMOS_CameraSuite_4.10.2.0-Linux64_ARM.deb \
+        ./FRAMOS-librealsense2-2.50.13-Linux64_ARM.deb \
     && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
This pull request fixed the docker build error by updating FRAMOS softwares to following version

- FRAMOS librealsense 2.50.13
- FRAMOS CameraSuite 4.10.2.0

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>