### PR TITLE
skip call setup-model.sh on NUC to suppress error message

### DIFF
--- a/docker/people/launch.sh
+++ b/docker/people/launch.sh
@@ -27,11 +27,16 @@ args=("$@")
 WS=$HOME/people_ws
 
 if [ "$1" == "build" ]; then
-    echo "Setup model"
-    /setup-model.sh $WS/src/track_people_py/models
-    if [ $? -ne 0 ]; then
-        echo "Failed to setup model"
-        exit 1
+    arch=$(uname -m)
+    if { [ $arch = "x86_64" ] && [ -n "$(which nvidia-smi)" ]; } || [ $arch = "aarch64" ]; then
+        echo "Setup model"
+        /setup-model.sh $WS/src/track_people_py/models
+        if [ $? -ne 0 ]; then
+            echo "Failed to setup model"
+            exit 1
+        fi
+    else
+        echo "Skip setup model. GPU is not detected."
     fi
 
     echo "Build workspace"


### PR DESCRIPTION
I found following error messages when building people workspace on NUC.
This error message shows because workspace  for people docker image is not used but built.
This pull request suppresses the error message by skipping setup-model.sh on NUC.

<details>
<summary>build messages</summary>

```
cabot@ace23-2:~/cabot-ros2$ ./build-docker.sh -w -c realsense people
Building workspaces
Building docker-compose-bag.yaml
Building docker-compose-common.yaml
Building workspace of docker-compose-common.yaml, people debug=false
WARN[0000] Found orphan containers ([cabot-ros2-map_data-1 cabot-ros2-map_server-1 cabot-ros2-mongodb-1]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
Setup model
You already have yolov4.cfg
You already have yolov4.weights
You already have coco.names
You already have rtmdet/rtmdet_s_8xb32-300e_coco_20220905_161602-387a891e.pth
prepare file for deployment...
run model deployment...
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
07/29 17:49:10 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "Codebases" registry tree. As a workaround, the current "Codebases" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
07/29 17:49:10 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "mmdet_tasks" registry tree. As a workaround, the current "mmdet_tasks" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
07/29 17:49:12 - mmengine - INFO - Start pipeline mmdeploy.apis.pytorch2onnx.torch2onnx in subprocess
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
07/29 17:49:12 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "Codebases" registry tree. As a workaround, the current "Codebases" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
07/29 17:49:12 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "mmdet_tasks" registry tree. As a workaround, the current "mmdet_tasks" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
Loads checkpoint by local backend from path: rtmdet/rtmdet_s_8xb32-300e_coco_20220905_161602-387a891e.pth
Process Process-2:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/dist-packages/mmdeploy/apis/core/pipeline_manager.py", line 107, in __call__
    ret = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/mmdeploy/apis/pytorch2onnx.py", line 63, in torch2onnx
    torch_model = task_processor.build_pytorch_model(model_checkpoint)
  File "/usr/local/lib/python3.10/dist-packages/mmdeploy/codebase/base/task.py", line 123, in build_pytorch_model
    load_checkpoint(model, model_checkpoint, map_location=self.device)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 636, in load_checkpoint
    checkpoint = _load_checkpoint(filename, map_location, logger)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 548, in _load_checkpoint
    return CheckpointLoader.load_checkpoint(filename, map_location, logger)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 330, in load_checkpoint
    return checkpoint_loader(filename, map_location)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 347, in load_from_local
    checkpoint = torch.load(filename, map_location=map_location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1028, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1256, in _legacy_load
    result = unpickler.load()
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1193, in persistent_load
    wrap_storage=restore_location(obj, location),
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1296, in restore_location
    return default_restore_location(storage, map_location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 381, in default_restore_location
    result = fn(storage, location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 274, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 258, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
07/29 17:49:13 - mmengine - ERROR - /usr/local/lib/python3.10/dist-packages/mmdeploy/apis/core/pipeline_manager.py - pop_mp_output - 80 - `mmdeploy.apis.pytorch2onnx.torch2onnx` with Call id: 0 failed. exit.
Finished to deploy rtmdet/end2end.engine
You already have rtmdet-ins/rtmdet-ins_s_8xb32-300e_coco_20221121_212604-fdc5d7ec.pth
prepare file for deployment...
run model deployment (ignore error because visualize pytorch model will fail if input image size is not 640x640)...
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
07/29 17:49:16 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "Codebases" registry tree. As a workaround, the current "Codebases" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
07/29 17:49:16 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "mmdet_tasks" registry tree. As a workaround, the current "mmdet_tasks" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
07/29 17:49:17 - mmengine - INFO - Start pipeline mmdeploy.apis.pytorch2onnx.torch2onnx in subprocess
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
07/29 17:49:18 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "Codebases" registry tree. As a workaround, the current "Codebases" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
07/29 17:49:18 - mmengine - WARNING - Failed to search registry with scope "mmdet" in the "mmdet_tasks" registry tree. As a workaround, the current "mmdet_tasks" registry in "mmdeploy" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmdet" is a correct scope, or whether the registry is initialized.
Loads checkpoint by local backend from path: rtmdet-ins/rtmdet-ins_s_8xb32-300e_coco_20221121_212604-fdc5d7ec.pth
Process Process-2:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/dist-packages/mmdeploy/apis/core/pipeline_manager.py", line 107, in __call__
    ret = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/mmdeploy/apis/pytorch2onnx.py", line 63, in torch2onnx
    torch_model = task_processor.build_pytorch_model(model_checkpoint)
  File "/usr/local/lib/python3.10/dist-packages/mmdeploy/codebase/base/task.py", line 123, in build_pytorch_model
    load_checkpoint(model, model_checkpoint, map_location=self.device)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 636, in load_checkpoint
    checkpoint = _load_checkpoint(filename, map_location, logger)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 548, in _load_checkpoint
    return CheckpointLoader.load_checkpoint(filename, map_location, logger)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 330, in load_checkpoint
    return checkpoint_loader(filename, map_location)
  File "/usr/local/lib/python3.10/dist-packages/mmengine/runner/checkpoint.py", line 347, in load_from_local
    checkpoint = torch.load(filename, map_location=map_location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1028, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1256, in _legacy_load
    result = unpickler.load()
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1193, in persistent_load
    wrap_storage=restore_location(obj, location),
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1296, in restore_location
    return default_restore_location(storage, map_location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 381, in default_restore_location
    result = fn(storage, location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 274, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 258, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
07/29 17:49:18 - mmengine - ERROR - /usr/local/lib/python3.10/dist-packages/mmdeploy/apis/core/pipeline_manager.py - pop_mp_output - 80 - `mmdeploy.apis.pytorch2onnx.torch2onnx` with Call id: 0 failed. exit.
fix deployed pipeline to enable is_crop_rtmdt_ins_mask option...
Finished to deploy rtmdet-ins/end2end.engine
Build workspace
Starting >>> cabot_msgs
Starting >>> track_people_msgs
Starting >>> cabot_people
Finished <<< cabot_people [0.08s]
Finished <<< track_people_msgs [0.41s]                                                                
Starting >>> track_people_py
Finished <<< cabot_msgs [0.46s]
Starting >>> cabot_common
Finished <<< track_people_py [0.26s]                                                             
Finished <<< cabot_common [0.29s]                  
Starting >>> track_people_cpp
Finished <<< track_people_cpp [0.11s]                     

Summary: 6 packages finished [0.99s]
Building docker-compose-gnss.yaml
WARN[0000] The "NTRIP_HOST" variable is not set. Defaulting to a blank string. 
WARN[0000] The "NTRIP_AUTHENTIFICATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "NTRIP_MOUNTPOINT" variable is not set. Defaulting to a blank string. 
WARN[0000] The "NTRIP_USERNAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "NTRIP_PASSWORD" variable is not set. Defaulting to a blank string. 
WARN[0000] The "NTRIP_CLIENT" variable is not set. Defaulting to a blank string. 
WARN[0000] The "RTK_STR_IN" variable is not set. Defaulting to a blank string. 
Building docker-compose-jetson-common.yaml
Building docker-compose-jetson-rs3-framos-production.yaml
Building docker-compose-jetson-rs3-framos.yaml
Building docker-compose-lint.yaml
Building docker-compose-mapping-gazebo.yaml
Building docker-compose-mapping-post-process.yaml
Building docker-compose-mapping.yaml
Building docker-compose-nuc-production.yaml
Building docker-compose-nuc.yaml
Building docker-compose-production.yaml
Building workspace of docker-compose-production.yaml, people debug=false
skip -- already built
Building docker-compose-rs3-framos-production.yaml
Building docker-compose-rs3-framos.yaml
Building docker-compose-rs3-production.yaml
Building docker-compose-rs3.yaml
Building docker-compose-server.yaml
Building docker-compose.yaml
Building workspace of docker-compose.yaml, people debug=false
skip -- already built
```

</details>

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>