### PR TITLE
fix Kalaman Filter process noise parameter to smooth velocity

### DIFF
--- a/track_people_py/launch/predict_kf.launch.py
+++ b/track_people_py/launch/predict_kf.launch.py
@@ -57,7 +57,7 @@ def generate_launch_description():
         LogInfo(msg=["no cabot_common"]) if workaround else RegisterEventHandler(OnShutdown(on_shutdown=[AppendLogDirPrefix("track_people_cpp-detect_darknet")])),
 
         DeclareLaunchArgument('kf_init_var', default_value='1.0'),
-        DeclareLaunchArgument('kf_process_var', default_value='1000.0'),
+        DeclareLaunchArgument('kf_process_var', default_value='1.0'),
         DeclareLaunchArgument('kf_measure_var', default_value='1.0'),
         DeclareLaunchArgument('duration_inactive_to_stop_publish', default_value=EnvironmentVariable('CABOT_DETECT_PEOPLE_CLEAR_TIME', default_value='0.2')),
         DeclareLaunchArgument('target_fps', default_value=EnvironmentVariable('CABOT_PEOPLE_PREDICT_FPS', default_value='15.0')),

--- a/track_people_py/launch/track_sort_3d.launch.py
+++ b/track_people_py/launch/track_sort_3d.launch.py
@@ -61,7 +61,7 @@ def generate_launch_description():
         DeclareLaunchArgument('iou_threshold', default_value='0.01'),
         DeclareLaunchArgument('iou_circle_size', default_value='0.5'),
         DeclareLaunchArgument('kf_init_var', default_value='1.0'),
-        DeclareLaunchArgument('kf_process_var', default_value='1000.0'),
+        DeclareLaunchArgument('kf_process_var', default_value='1.0'),
         DeclareLaunchArgument('kf_measure_var', default_value='1.0'),
         DeclareLaunchArgument('minimum_valid_track_duration', default_value='0.0'),
         DeclareLaunchArgument('duration_inactive_to_remove', default_value='2.0'),

--- a/track_people_py/track_people_py/predict_kf_abstract.py
+++ b/track_people_py/track_people_py/predict_kf_abstract.py
@@ -64,7 +64,7 @@ class PredictKfAbstract(rclpy.node.Node):
         # start initialization
         self.input_time = self.declare_parameter('input_time', 5).value # number of frames to start prediction
         self.kf_init_var = self.declare_parameter('kf_init_var', 1.0).value
-        self.kf_process_var = self.declare_parameter('kf_process_var', 1000.0).value
+        self.kf_process_var = self.declare_parameter('kf_process_var', 1.0).value
         self.kf_measure_var = self.declare_parameter('kf_measure_var', 1.0).value
         self.duration_inactive_to_remove = self.declare_parameter('duration_inactive_to_remove', 2.0).value # duration (seconds) to remove an inactive track (this value should be enough long because track_obstacle_py returns recovered tracks)
         self.duration_inactive_to_stop_publish = self.declare_parameter('duration_inactive_to_stop_publish', 0.2).value # duration (seconds) to stop publishing an inactive track in people topic

--- a/track_people_py/track_people_py/track_abstract_people.py
+++ b/track_people_py/track_people_py/track_abstract_people.py
@@ -44,7 +44,7 @@ class AbsTrackPeople(rclpy.node.Node):
         self.iou_threshold = self.declare_parameter('iou_threshold', 0.01).value
         self.iou_circle_size = self.declare_parameter('iou_circle_size', 0.5).value
         self.kf_init_var = self.declare_parameter('kf_init_var', 1.0).value
-        self.kf_process_var = self.declare_parameter('kf_process_var', 1000.0).value
+        self.kf_process_var = self.declare_parameter('kf_process_var', 1.0).value
         self.kf_measure_var = self.declare_parameter('kf_measure_var', 1.0).value
         self.minimum_valid_track_duration = self.declare_parameter('minimum_valid_track_duration', 0.0).value
         self.duration_inactive_to_remove = self.declare_parameter('duration_inactive_to_remove', 2.0).value

--- a/track_people_py/track_people_py/track_utils/tracker_sort_3d.py
+++ b/track_people_py/track_people_py/track_utils/tracker_sort_3d.py
@@ -30,7 +30,7 @@ from . import kf_utils
 
 
 class TrackerSort3D:
-    def __init__(self, iou_threshold=0.01, iou_circle_size=0.5, kf_init_var=1.0, kf_process_var=1000.0, kf_measure_var=1.0,
+    def __init__(self, iou_threshold=0.01, iou_circle_size=0.5, kf_init_var=1.0, kf_process_var=1.0, kf_measure_var=1.0,
                  minimum_valid_track_duration=0.3, duration_inactive_to_remove=2.0, n_colors=100):
         # Initialization
         #


### PR DESCRIPTION
modified Kalman Filter parameters to fix the issues that stationary tags are not assigned for stationary people/obstacles

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>