### PR TITLE
fix bug, diagnostic warning message for ObstaclePredict always shows when Livox is used

### DIFF
--- a/track_people_cpp/launch/track_obstacles.launch.py
+++ b/track_people_cpp/launch/track_obstacles.launch.py
@@ -72,6 +72,7 @@ def generate_launch_description():
             parameters=[{
                 'duration_inactive_to_stop_publish': 0.2,
                 'stationary_detect_threshold_duration': 1.0,
+                'target_fps': target_fps,
                 'diagnostic_name': 'ObstaclePredict'
             }],
             remappings=[('/obstacle/people', '/obstacles')],


### PR DESCRIPTION
DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>